### PR TITLE
Added a command to open bash in workspace root

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@ This has now largely been superceeded by built-in VSCode functionality in
 
 ----
 
-This small Visual Studio Code extension adds a "bash" command to VSCode that allows you to start git-bash with the current working folder
+This small Visual Studio Code extension adds a "bash" commands to VSCode that allows you to start git-bash with the current working folder
 as the VSCode workspace's root folder.
 
-Press F1 and then type "bash" to start git-bash.exe.
+Plugin provides two commands:
+
+* `bash` will open bash in your current file's directory.
+* `bash in workspace` will open bash always in the root workspace directory, despite what file is opened.
+
+Just press F1 and then type any of above commands to start git-bash.exe.
 
 **Note that you will need to have git-bash.exe on the environment path.**
 

--- a/package.json
+++ b/package.json
@@ -16,13 +16,18 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:extension.startGitBash"
+        "onCommand:extension.startGitBash",
+        "onCommand:extension.startWorkspaceGitBash"
     ],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [{
             "command": "extension.startGitBash",
             "title": "bash"
+        },
+        {
+            "command": "extension.startWorkspaceGitBash",
+            "title": "bash in workspace"
         }]
     },
     "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ function spawnGitBash(activateOnPath:string) : boolean {
 /**
  * Start bash in the current VSCode workspace root folder
  */
-function startBash() {
+function startBash(forceWorkspace:boolean) {
     try {
         // If spawn wasn't successfully loaded there's nothing we can do
         if( !spawn ) {
@@ -40,7 +40,7 @@ function startBash() {
 
         // If there's a file open we'll try and it's directory - even without a workspace
         const activeEditor = vscode.window.activeTextEditor;
-        if( activeEditor!=null ) {
+        if( activeEditor!=null && forceWorkspace !== true ) {
             const filePath = path.dirname(activeEditor.document.fileName);
             spawnGitBash(filePath);
             return;
@@ -66,8 +66,11 @@ export function activate(context: vscode.ExtensionContext) {
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with  registerCommand
     // The commandId parameter must match the command field in package.json
-    let disposable = vscode.commands.registerCommand('extension.startGitBash', startBash);
+    let disposable = vscode.commands.registerCommand('extension.startGitBash', () => startBash( false ) );
+    let workspaceDisposable = vscode.commands.registerCommand('extension.startWorkspaceGitBash', () => startBash( true ) );
+
     context.subscriptions.push(disposable);
+    context.subscriptions.push(workspaceDisposable);
 }
 
 // This method is called when the extension is deactivated


### PR DESCRIPTION
Fixes #6 - added a second command to open bash in root dir, despite which file is open.